### PR TITLE
fix: Fixes app create

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,6 @@ load_dotenv()
 db = SQLAlchemy()
 migrate = Migrate()
 
-'''
 def create_app(config_name='development'):
     app = Flask(__name__)
 
@@ -65,6 +64,6 @@ def create_app(config_name='development'):
         }
 
     return app
-'''
+
 
 app = create_app()


### PR DESCRIPTION
In this pr, the error "NameError: name 'create_app' is not defined." identified in the issue:  fix: Create app #1 has been fixed by removing the comment located in __init.py__ 